### PR TITLE
Fix demo

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt install -y software-properties-common && \
     add-apt-repository universe
 
 RUN apt update && \
-    apt install -y curl git  && \
+    apt install -y curl git && \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
@@ -26,6 +26,7 @@ RUN apt update && \
     apt install -y \
         build-essential \
         cmake \
+        git-lfs \
         python3-flake8 \
         python3-rosdep \
         python3-setuptools \

--- a/demo/launch/pipeline_testbench.launch.py
+++ b/demo/launch/pipeline_testbench.launch.py
@@ -46,7 +46,7 @@ def launch_setup(context, *args, **kwargs):
         .trajectory_execution(file_path="config/moveit_controllers.yaml")
         .moveit_cpp(
             os.path.join(
-                get_package_share_directory("moveit2_tutorials"),
+                get_package_share_directory("moveit_drake"),
                 "config",
                 "testbench_moveit_cpp.yaml",
             )
@@ -101,7 +101,7 @@ def launch_setup(context, *args, **kwargs):
     # MoveItCpp demo executable
     moveit_cpp_node = Node(
         name="pipeline_testbench_example",
-        package="moveit2_tutorials",
+        package="moveit_drake",
         executable="pipeline_testbench_example",
         output="screen",
         parameters=[
@@ -113,7 +113,7 @@ def launch_setup(context, *args, **kwargs):
 
     # RViz
     rviz_config_file = os.path.join(
-        get_package_share_directory("moveit2_tutorials"),
+        get_package_share_directory("moveit_drake"),
         "config",
         "testbench_config.rviz",
     )

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>moveit_core</depend>
   <depend>moveit_visual_tools</depend>
   <depend>rviz_visual_tools</depend>
+  <depend>warehouse-ros-sqlite</depend>
 
   <build_depend>eigen</build_depend>
   <build_depend>moveit_common</build_depend>
@@ -25,6 +26,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>moveit</exec_depend>
   <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
+
   <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>moveit_py</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
@kamiradi Do you mind testing if that fixes the demo. This PR:

- updates all moveit2_tutorials calls to moveit_drake
- installs git-lfs --> otherwise the databases are not properly cloned and you get a segfault when you launch the demo (you'll need to delete moveit_benchmarking_resources and reclone once gitlfs is installed
- Add warehouse-ros-sqlite dependency to ensure it is installed with rosdep