### PR TITLE
Docker fixes and parameter cleanups

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM robotlocomotion/drake:1.29.0
-MAINTAINER Aditya Kamireddypalli "kamireddypalliaditya@gmail.com"
+LABEL maintainer="Aditya Kamireddypalli kamireddypalliaditya@gmail.com"
 
 ENV ROS_DISTRO=humble
 ENV WORKSPACE=/root/workspace/
@@ -25,18 +25,18 @@ RUN apt update && \
     apt upgrade -y && \
     apt install -y \
         build-essential \
+        clang-format-14 \
         cmake \
         git-lfs \
+        python3-colcon-common-extensions \
         python3-flake8 \
         python3-rosdep \
         python3-setuptools \
         python3-vcstool \
-        python3-colcon-common-extensions \
+        ros-dev-tools \
         ros-${ROS_DISTRO}-desktop \
         ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-        ros-dev-tools \
-        wget \
-        clang-format-14
+        wget
 
 RUN pip3 install colcon-mixin pre-commit && \
     colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \

--- a/.docker/ros_entrypoint.sh
+++ b/.docker/ros_entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# setup ros2 environment
+# Setup ROS 2 environment
 source "/opt/ros/$ROS_DISTRO/setup.bash" --
 source "${WORKSPACE}/install/setup.bash" --
 
-# execute docker command
+# Ensure pre-commit can be run from inside the container
+git config --global --add safe.directory "${WORKSPACE}/src/moveit_drake"
+
+# Execute docker command
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ moveit)
     cd moveit_drake
     docker compose build
 
-This should give you an image with `drake` and `moveit2`. Next, create a
-container with the following and create shell access.
+This should give you an image with `drake` and `moveit2`.
+Next, create a container with the following and create shell access.
 
     docker compose up
     docker compose exec -it moveit_drake bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
-      - TERM=xterm-256-color
+      - TERM=xterm-256color
     volumes:
       - /tmp/.X11-unix:/tml/.X11-unix:rw
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -7,7 +7,7 @@ ktopt_interface:
       gt_eq<>: [1]
     }
   }
-  control_points: {
+  num_control_points: {
     type: int,
     description: "Number of control points used to represent the B-Spline.",
     default_value: 10,
@@ -15,15 +15,15 @@ ktopt_interface:
       gt_eq<>: [1]
     }
   }
-  trajectory_res: {
-    type: int,
+  trajectory_time_step: {
+    type: float,
     description: "Timestep resolution where the KTOpt trajectory is evaluated and reported.",
-    default_value: 101,
+    default_value: 0.01,
     validation: {
-      gt_eq<>: [2]
+      gt<>: [0.0]
     }
   }
-  collision_check_resolution: {
+  num_collision_check_points: {
     type: int,
     description: "Number of collision checks to perform along the trajectory.",
     default_value: 25,

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -16,8 +16,8 @@ ktopt_interface:
     }
   }
   trajectory_time_step: {
-    type: float,
-    description: "Timestep resolution where the KTOpt trajectory is evaluated and reported.",
+    type: double,
+    description: "Timestep resolution, in seconds, where the KTOpt trajectory is evaluated and reported.",
     default_value: 0.01,
     validation: {
       gt<>: [0.0]
@@ -33,7 +33,7 @@ ktopt_interface:
   }
   collision_check_lower_distance_bound: {
     type: double,
-    description: "Lower bound, in meters, for collision check minimum distance constraint.",
+    description: "Lower bound, in meters, for the collision check minimum distance constraint.",
     default_value: 0.01,
     validation: {
       gt_eq<>: [0.0]

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -10,10 +10,32 @@ ktopt_interface:
   control_points: {
     type: int,
     description: "Number of control points used to represent the B-Spline.",
-    default_value: 10
+    default_value: 10,
+    validation: {
+      gt_eq<>: [1]
+    }
   }
   trajectory_res: {
     type: int,
     description: "Timestep resolution where the KTOpt trajectory is evaluated and reported.",
-    default_value: 101
+    default_value: 101,
+    validation: {
+      gt_eq<>: [2]
+    }
+  }
+  collision_check_resolution: {
+    type: int,
+    description: "Number of collision checks to perform along the trajectory.",
+    default_value: 25,
+    validation: {
+      gt_eq<>: [2]
+    }
+  }
+  collision_check_lower_distance_bound: {
+    type: double,
+    description: "Lower bound, in meters, for collision check minimum distance constraint.",
+    default_value: 0.01,
+    validation: {
+      gt_eq<>: [0.0]
+    }
   }

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -1,7 +1,7 @@
 ktopt_interface:
   num_iterations: {
     type: int,
-    description: "dummy",
+    description: "Number of iterations for the Drake mathematical program solver.",
     default_value: 1000,
     validation: {
       gt_eq<>: [1]
@@ -9,11 +9,11 @@ ktopt_interface:
   }
   control_points: {
     type: int,
-    description: "Number of control points used to represent the B-Spline",
+    description: "Number of control points used to represent the B-Spline.",
     default_value: 10
   }
   trajectory_res: {
     type: int,
-    description: "Timestep resolution where the KTOpt trajectory is evaluated and reported",
+    description: "Timestep resolution where the KTOpt trajectory is evaluated and reported.",
     default_value: 101
   }

--- a/src/ktopt_planner_manager.cpp
+++ b/src/ktopt_planner_manager.cpp
@@ -9,8 +9,6 @@
 #include <std_msgs/msg/string.hpp>
 #include <ktopt_interface/ktopt_planning_context.hpp>
 
-// just so that this builds
-
 namespace ktopt_interface
 {
 using std::placeholders::_1;

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -13,9 +13,6 @@ rclcpp::Logger getLogger()
 {
   return moveit::getLogger("moveit.planners.ktopt_interface.planning_context");
 }
-
-double COLLISION_CHECK_RESOLUTION = 25.0;
-double LOWER_BOUND = 0.01;
 }  // namespace
 
 KTOptPlanningContext::KTOptPlanningContext(const std::string& name, const std::string& group_name,
@@ -122,11 +119,11 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   trajopt.SetInitialGuess(trajopt.ReconstructTrajectory(result));
 
   // add collision constraints
-  for (double s = 0.0; s <= COLLISION_CHECK_RESOLUTION; s++)
+  for (int s = 0; s <= params._collision_check_resolution; ++s)
   {
-    trajopt.AddPathPositionConstraint(std::make_shared<MinimumDistanceLowerBoundConstraint>(&plant, LOWER_BOUND,
-                                                                                            &plant_context),
-                                      s / COLLISION_CHECK_RESOLUTION);
+    trajopt.AddPathPositionConstraint(std::make_shared<MinimumDistanceLowerBoundConstraint>(
+                                          &plant, params_.collision_check_lower_distance_bound, &plant_context),
+                                      static_cast<double>(s) / params._collision_check_resolution);
   }
 
   // The previous solution is used to warm-start the collision checked

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -122,7 +122,7 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   trajopt.SetInitialGuess(trajopt.ReconstructTrajectory(result));
 
   // add collision constraints
-  for (double s = 0.0; s <= 25.0; s++)
+  for (double s = 0.0; s <= COLLISION_CHECK_RESOLUTION; s++)
   {
     trajopt.AddPathPositionConstraint(std::make_shared<MinimumDistanceLowerBoundConstraint>(&plant, LOWER_BOUND,
                                                                                             &plant_context),
@@ -135,7 +135,7 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 
   // package up the resulting trajectory
   auto traj = trajopt.ReconstructTrajectory(collision_free_result);
-  const size_t num_pts = params_.trajectory_res;  // TODO: should be sample time based instead
+  const size_t num_pts = params_.trajectory_res;  // TODO(#28): should be sample time based instead
   const auto time_step = traj.end_time() / static_cast<double>(num_pts - 1);
   res.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(start_state.getRobotModel(), group);
   res.trajectory->clear();

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -128,8 +128,7 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
                                       static_cast<double>(s) / (params_.num_collision_check_points - 1));
   }
 
-  // The previous solution is used to warm-start the collision checked
-  // optimization problem
+  // The previous solution is used to warm-start the collision checked optimization problem
   auto collision_free_result = Solve(prog);
 
   // package up the resulting trajectory
@@ -143,6 +142,7 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   assert(traj.rows() == active_joints.size());
 
   visualizer_->StartRecording();
+  double t_prev = 0.0;
   const auto num_pts = static_cast<size_t>(std::ceil(traj.end_time() / params_.trajectory_time_step) + 1);
   for (int i = 0; i < num_pts; ++i)
   {
@@ -153,7 +153,8 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
     const auto waypoint = std::make_shared<moveit::core::RobotState>(start_state);
     setJointPositions(pos_val, active_joints, *waypoint);
     setJointVelocities(vel_val, active_joints, *waypoint);
-    res.trajectory->addSuffixWayPoint(waypoint, time_step);
+    res.trajectory->addSuffixWayPoint(waypoint, t - t_prev);
+    t_prev = t;
 
     plant.SetPositions(&plant_context, pos_val);
     auto& vis_context = visualizer_->GetMyContextFromRoot(*diagram_context_);


### PR DESCRIPTION
As the title says, was just going through and found some slight fixes to the Docker workflow... and during rebuilds I fixed a few other small things as well. 

The important stuff is:

* The `TERM=xterm-256color` env variable had a typo in it, which gave errors when trying to run bash commands in the container like `clear`
* There was one more extra thing needed in the entrypoint for `pre-commit run -a` to work correctly.
* Changed some collision check constraints from constants to actual parameters.
* Changed the trajectory time resolution to seconds (Closes #28)