### PR TITLE
Cleanup planning scene geometry code

### DIFF
--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -43,6 +43,7 @@ using drake::geometry::PerceptionProperties;
 using drake::geometry::ProximityProperties;
 using drake::geometry::Role;
 using drake::geometry::SceneGraph;
+using drake::geometry::Shape;
 using drake::geometry::SourceId;
 using drake::geometry::Sphere;
 using drake::math::RigidTransformd;

--- a/moveit_drake.repos
+++ b/moveit_drake.repos
@@ -1,7 +1,7 @@
 repositories:
   moveit_visual_tools:
     type: git
-    url: https://github.com/ros-planning/moveit_visual_tools
+    url: https://github.com/moveit/moveit_visual_tools
     version: ros2
   rviz_visual_tools:
     type: git
@@ -9,15 +9,15 @@ repositories:
     version: ros2
   moveit2:
     type: git
-    url: https://github.com/ros-planning/moveit2
+    url: https://github.com/moveit/moveit2
     version: main
   moveit_resources:
     type: git
-    url: https://github.com/ros-planning/moveit_resources
+    url: https://github.com/moveit/moveit_resources
     version: ros2
   moveit_msgs:
     type: git
-    url: https://github.com/ros-planning/moveit_msgs
+    url: https://github.com/moveit/moveit_msgs
     version: ros2
   moveit_benchmark_resources:
     type: git

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -270,14 +270,9 @@ void KTOptPlanningContext::transcribePlanningScene(const planning_scene::Plannin
           shape_ptr = std::make_unique<Cylinder>(object_ptr->radius, object_ptr->length);
           break;
         }
-        case shapes::ShapeType::UNKNOWN_SHAPE:
-        {
-          RCLCPP_WARN(getLogger(), "Unknown shape, ignoring in scene graph");
-          break;
-        }
         default:
         {
-          RCLCPP_WARN(getLogger(), "Shape TYPE conversion to drake is not implemented");
+          RCLCPP_WARN(getLogger(), "Unsupported shape for '" + object_name + "', ignoring in scene graph.");
           break;
         }
       }

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -272,7 +272,7 @@ void KTOptPlanningContext::transcribePlanningScene(const planning_scene::Plannin
         }
         default:
         {
-          RCLCPP_WARN(getLogger(), "Unsupported shape for '" + object_name + "', ignoring in scene graph.");
+          RCLCPP_WARN(getLogger(), "Unsupported shape for '%s', ignoring in scene graph.", shape_name.c_str());
           break;
         }
       }


### PR DESCRIPTION
This PR cleans up some of the repetitive code in the planning scene geometry transcription, plus some other small stuff here and there.

I could get the code to compile, but for some reason the `vcs import` part of the container build is failing... so I'm unable to test it out on the latest image build. Can you guys try this out @sjahr @kamiradi?

I get this error:

```
Could not clone repository 'https://github.com/sjahr/moveit_benchmark_resources':
fatal: destination path '.' already exists and is not an empty directory.
```