### PR TITLE
Set position constraints via Moveit's PositionConstraint message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rviz_visual_tools REQUIRED)
 find_package(warehouse_ros REQUIRED)
+find_package(shape_msgs REQUIRED)
 
 generate_parameter_library(ktopt_moveit_parameters
                            res/ktopt_moveit_parameters.yaml)
@@ -35,7 +36,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     moveit_visual_tools
     rclcpp
     rviz_visual_tools
-    warehouse_ros)
+    warehouse_ros
+    shape_msgs)
 
 include_directories(include)
 
@@ -51,7 +53,7 @@ add_library(
   src/conversions.cpp)
 
 ament_target_dependencies(moveit_drake rclcpp pluginlib moveit_core moveit_msgs
-                          EIGEN3)
+                          EIGEN3 shape_msgs)
 target_link_libraries(moveit_drake drake::drake ktopt_moveit_parameters)
 
 # Ensure that the plugin finds libdrake.so at runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,14 @@ add_library(
   # Conversions
   src/conversions.cpp)
 
-ament_target_dependencies(moveit_drake rclcpp pluginlib moveit_core moveit_msgs
-                          EIGEN3 shape_msgs)
+ament_target_dependencies(
+  moveit_drake
+  rclcpp
+  pluginlib
+  moveit_core
+  moveit_msgs
+  EIGEN3
+  shape_msgs)
 target_link_libraries(moveit_drake drake::drake ktopt_moveit_parameters)
 
 # Ensure that the plugin finds libdrake.so at runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     moveit_visual_tools
     rclcpp
     rviz_visual_tools
-    warehouse_ros
-    shape_msgs)
+    shape_msgs
+    warehouse_ros)
 
 include_directories(include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,11 @@ add_library(
 
 ament_target_dependencies(
   moveit_drake
-  rclcpp
-  pluginlib
+  EIGEN3
   moveit_core
   moveit_msgs
-  EIGEN3
+  pluginlib
+  rclcpp
   shape_msgs)
 target_link_libraries(moveit_drake drake::drake ktopt_moveit_parameters)
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ ros2 launch moveit_drake pipeline_testbench.launch.py
 - Use [pre-commit to format your
   code](https://moveit.ros.org/documentation/contributing/code/#pre-commit-formatting-checks)
 
+Within the container you can run the following command to format the code
+
     # inside the moveit_drake package
     pre-commit run -a
 

--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -23,6 +23,8 @@
 #include "drake/visualization/visualization_config.h"
 #include "drake/visualization/visualization_config_functions.h"
 #include <drake/multibody/inverse_kinematics/minimum_distance_lower_bound_constraint.h>
+#include <drake/multibody/inverse_kinematics/position_constraint.h>
+
 
 namespace ktopt_interface
 {
@@ -51,6 +53,7 @@ using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::MinimumDistanceLowerBoundConstraint;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::PackageMap;
+using drake::multibody::PositionConstraint;
 using drake::multibody::Parser;
 using drake::planning::trajectory_optimization::KinematicTrajectoryOptimization;
 using drake::solvers::Solve;

--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -25,7 +25,6 @@
 #include <drake/multibody/inverse_kinematics/minimum_distance_lower_bound_constraint.h>
 #include <drake/multibody/inverse_kinematics/position_constraint.h>
 
-
 namespace ktopt_interface
 {
 // declare all namespaces to be used
@@ -53,8 +52,8 @@ using drake::multibody::AddMultibodyPlantSceneGraph;
 using drake::multibody::MinimumDistanceLowerBoundConstraint;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::PackageMap;
-using drake::multibody::PositionConstraint;
 using drake::multibody::Parser;
+using drake::multibody::PositionConstraint;
 using drake::planning::trajectory_optimization::KinematicTrajectoryOptimization;
 using drake::solvers::Solve;
 using drake::systems::Context;

--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <moveit/planning_interface/planning_interface.h>
+#include <shape_msgs/msg/solid_primitive.h>
 #include <ktopt_moveit_parameters.hpp>
 
 // relevant drake includes
@@ -49,6 +50,7 @@ using drake::geometry::SourceId;
 using drake::geometry::Sphere;
 using drake::math::RigidTransformd;
 using drake::multibody::AddMultibodyPlantSceneGraph;
+using drake::multibody::Frame;
 using drake::multibody::MinimumDistanceLowerBoundConstraint;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::PackageMap;
@@ -80,6 +82,8 @@ public:
 
   void setRobotDescription(std::string robot_description);
   void transcribePlanningScene(const planning_scene::PlanningScene& planning_scene);
+  void addPathPositionConstraints(KinematicTrajectoryOptimization& trajopt, const MultibodyPlant<double>& plant,
+                                  const Frame<double>& link_ee_frame, Context<double>& plant_context);
 
 private:
   const ktopt_interface::Params params_;

--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -83,7 +83,7 @@ public:
   void setRobotDescription(std::string robot_description);
   void transcribePlanningScene(const planning_scene::PlanningScene& planning_scene);
   void addPathPositionConstraints(KinematicTrajectoryOptimization& trajopt, const MultibodyPlant<double>& plant,
-                                  const Frame<double>& link_ee_frame, Context<double>& plant_context);
+                                  Context<double>& plant_context);
 
 private:
   const ktopt_interface::Params params_;

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>moveit_visual_tools</depend>
   <depend>rviz_visual_tools</depend>
   <depend>warehouse_ros_sqlite</depend>
+  <depend>shape_msgs</depend>
 
   <build_depend>eigen</build_depend>
   <build_depend>moveit_common</build_depend>

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -49,6 +49,22 @@ ktopt_interface:
       gt_eq<>: [0.0]
     }
   }
+  num_position_constraint_points: {
+    type: int,
+    description: "Number of points on the path that moveit's bounding box constraint needs to be imposed",
+    default_value: 10,
+    validation: {
+      gt_eq<>: [0.0]
+    }
+  }
+  num_orientation_constraint_points: {
+    type: int,
+    description: "Number of points on the path where moveit's orientation constraint needs to be imposed",
+    default_value: 10,
+    validation: {
+      gt_eq<>: [0.0]
+    }
+  }
   joint_jerk_bound: {
     type: double,
     description: "Maximum jerk that is allowed for generated trajectory",

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -4,11 +4,6 @@ ktopt_interface:
     description: "Robot description to be loaded by the internal Drake MultibodyPlant",
     default_value: "package://drake_models/franka_description/urdf/panda_arm_hand.urdf",
   }
-  link_ee: {
-    type: string,
-    description: "Name of the end-effector frame as per urdf/srdf",
-    default_value: "panda_hand"
-  }
   num_iterations: {
     type: int,
     description: "Number of iterations for the Drake mathematical program solver.",

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -6,7 +6,7 @@ ktopt_interface:
   }
   link_ee: {
     type: string,
-    description: "Name of the end-effector frame as per urdf/sdf",
+    description: "Name of the end-effector frame as per urdf/srdf",
     default_value: "panda_hand"
   }
   num_iterations: {

--- a/res/ktopt_moveit_parameters.yaml
+++ b/res/ktopt_moveit_parameters.yaml
@@ -4,6 +4,11 @@ ktopt_interface:
     description: "Robot description to be loaded by the internal Drake MultibodyPlant",
     default_value: "package://drake_models/franka_description/urdf/panda_arm_hand.urdf",
   }
+  link_ee: {
+    type: string,
+    description: "Name of the end-effector frame as per urdf/sdf",
+    default_value: "panda_hand"
+  }
   num_iterations: {
     type: int,
     description: "Number of iterations for the Drake mathematical program solver.",

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -1,11 +1,10 @@
 #include <cmath>
 
-#include <moveit/drake/conversions.hpp>
-#include <moveit/robot_state/conversions.h>
-#include <moveit/planning_interface/planning_interface.h>
 #include <moveit/constraint_samplers/constraint_sampler_manager.h>
+#include <moveit/drake/conversions.hpp>
+#include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
-#include <shape_msgs/msg/solid_primitive.h>
+#include <moveit/robot_state/conversions.h>
 
 #include "ktopt_interface/ktopt_planning_context.hpp"
 
@@ -31,8 +30,8 @@ KTOptPlanningContext::KTOptPlanningContext(const std::string& name, const std::s
 
 void KTOptPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& /*res*/)
 {
-  RCLCPP_ERROR(getLogger(),
-               "KTOptPlanningContext::solve(planning_interface::MotionPlanDetailedResponse&) is not implemented!");
+  RCLCPP_ERROR(getLogger(), "KTOptPlanningContext::solve(planning_interface::"
+                            "MotionPlanDetailedResponse&) is not implemented!");
   return;
 }
 
@@ -181,40 +180,7 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   trajopt.AddDurationConstraint(0.5, 5);
 
   // process path_constraints
-  if (!req.path_constraints.position_constraints.empty())
-  {
-    for (const auto& position_constraint : req.path_constraints.position_constraints)
-    {
-      // Extract the bounding box's center (primitive pose)
-      const auto& primitive_pose = position_constraint.constraint_region.primitive_poses[0];
-      Eigen::Vector3d box_center(primitive_pose.position.x, primitive_pose.position.y, primitive_pose.position.z);
-
-      // Extract dimensions of the bounding box from
-      // constraint_region.primitives Assuming it is a box
-      // (shape_msgs::SolidPrimitive::BOX) and has dimensions in [x, y, z]
-      const auto& primitive = position_constraint.constraint_region.primitives[0];
-      if (primitive.type == shape_msgs::msg::SolidPrimitive::BOX)
-      {
-        double x_dim = primitive.dimensions[0] / 2.0;
-        double y_dim = primitive.dimensions[1] / 2.0;
-        double z_dim = primitive.dimensions[2] / 2.0;
-
-        // Calculate the lower and upper bounds based on the box dimensions
-        // around the center
-        Eigen::Vector3d lower_bound = box_center - Eigen::Vector3d(x_dim, y_dim, z_dim);
-        Eigen::Vector3d upper_bound = box_center + Eigen::Vector3d(x_dim, y_dim, z_dim);
-
-        // Add position constraint to each knot point of the trajectory
-        for (int i = 0; i < 10; ++i)
-        {
-          trajopt.AddPathPositionConstraint(
-              std::make_shared<PositionConstraint>(&plant, plant.world_frame(), lower_bound, upper_bound, link_ee_frame,
-                                                   Eigen::Vector3d(0.0, 0.1, 0.0), &plant_context),
-              static_cast<double>(i) / 10.0);
-        }
-      }
-    }
-  }
+  addPathPositionConstraints(trajopt, plant, link_ee_frame, plant_context);
 
   // solve the program
   auto result = Solve(prog);
@@ -238,7 +204,8 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
                                       static_cast<double>(s) / (params_.num_collision_check_points - 1));
   }
 
-  // The previous solution is used to warm-start the collision checked optimization problem
+  // The previous solution is used to warm-start the collision checked
+  // optimization problem
   auto collision_free_result = Solve(prog);
 
   // package up the resulting trajectory
@@ -257,7 +224,8 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
     plant.SetPositions(&plant_context, traj.value(t));
     auto& vis_context = visualizer_->GetMyContextFromRoot(*diagram_context_);
     visualizer_->ForcedPublish(vis_context);
-    // Without these sleeps, the visualizer won't give you time to load your browser
+    // Without these sleeps, the visualizer won't give you time to load your
+    // browser
     // TODO: This should not hold up planning time
     std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(params_.trajectory_time_step * 10000.0)));
   }
@@ -265,6 +233,53 @@ void KTOptPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   visualizer_->PublishRecording();
   res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
   return;
+}
+
+void KTOptPlanningContext::addPathPositionConstraints(KinematicTrajectoryOptimization& trajopt,
+                                                      const MultibodyPlant<double>& plant,
+                                                      const Frame<double>& link_ee_frame,
+                                                      Context<double>& plant_context)
+{
+  // retrieve the motion planning request
+  const auto& req = getMotionPlanRequest();
+
+  // check for path position constraints
+  if (!req.path_constraints.position_constraints.empty())
+  {
+    for (const auto& position_constraint : req.path_constraints.position_constraints)
+    {
+      // Extract the bounding box's center (primitive pose)
+      const auto& primitive_pose = position_constraint.constraint_region.primitive_poses[0];
+      Eigen::Vector3d box_center(primitive_pose.position.x, primitive_pose.position.y, primitive_pose.position.z);
+
+      // Extract dimensions of the bounding box from
+      // constraint_region.primitives Assuming it is a box
+      // (shape_msgs::SolidPrimitive::BOX) and has dimensions in [x, y, z]
+      const auto& primitive = position_constraint.constraint_region.primitives[0];
+      if (primitive.type != shape_msgs::msg::SolidPrimitive::BOX)
+      {
+        continue;
+      }
+
+      double x_dim = primitive.dimensions[0] / 2.0;
+      double y_dim = primitive.dimensions[1] / 2.0;
+      double z_dim = primitive.dimensions[2] / 2.0;
+
+      // Calculate the lower and upper bounds based on the box dimensions
+      // around the center
+      Eigen::Vector3d lower_bound = box_center - Eigen::Vector3d(x_dim, y_dim, z_dim);
+      Eigen::Vector3d upper_bound = box_center + Eigen::Vector3d(x_dim, y_dim, z_dim);
+
+      // Add position constraint to each knot point of the trajectory
+      for (int i = 0; i < 10; ++i)
+      {
+        trajopt.AddPathPositionConstraint(
+            std::make_shared<PositionConstraint>(&plant, plant.world_frame(), lower_bound, upper_bound, link_ee_frame,
+                                                 Eigen::Vector3d(0.0, 0.0, 0.0), &plant_context),
+            static_cast<double>(i) / (params_.num_position_constraint_points - 1));
+      }
+    }
+  }
 }
 
 bool KTOptPlanningContext::terminate()
@@ -287,7 +302,8 @@ void KTOptPlanningContext::setRobotDescription(std::string robot_description)
   auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(builder.get(), 0.0);
 
   // TODO:(kamiradi) Figure out object parsing
-  // auto robot_instance = Parser(plant_, scene_graph_).AddModelsFromString(robot_description_, ".urdf");
+  // auto robot_instance = Parser(plant_,
+  // scene_graph_).AddModelsFromString(robot_description_, ".urdf");
 
   const char* ModelUrl = params_.drake_robot_description.c_str();
   const std::string urdf = PackageMap{}.ResolveUrl(ModelUrl);

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -258,6 +258,7 @@ void KTOptPlanningContext::addPathPositionConstraints(KinematicTrajectoryOptimiz
       const auto& primitive = position_constraint.constraint_region.primitives[0];
       if (primitive.type != shape_msgs::msg::SolidPrimitive::BOX)
       {
+        RCLCPP_WARN(getLogger(), "Expects a bounding box constraint as a SolidPrimitive::BOX");
         continue;
       }
 
@@ -271,7 +272,7 @@ void KTOptPlanningContext::addPathPositionConstraints(KinematicTrajectoryOptimiz
       Eigen::Vector3d upper_bound = box_center + Eigen::Vector3d(x_dim, y_dim, z_dim);
 
       // Add position constraint to each knot point of the trajectory
-      for (int i = 0; i < 10; ++i)
+      for (int i = 0; i < params_.num_position_constraint_points; ++i)
       {
         trajopt.AddPathPositionConstraint(
             std::make_shared<PositionConstraint>(&plant, plant.world_frame(), lower_bound, upper_bound, link_ee_frame,


### PR DESCRIPTION
This PR setsup a MoveIt PositionConstraint transcription. It achieves the following
- Reads Constraints in the MotionPlanningRequest
- retrieves PostionConstraint based box constraint
- Transcribes a drake Bounding Box constraint based on dimensions and pose of the box constraint. 