### PR TITLE
Fix dependency exports and update to .hpp includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ install(
   DESTINATION include/drake)
 
 ament_export_targets(moveit_drakeTargets HAS_LIBRARY_TARGET)
-ament_export_dependencies(moveit_core drake::drake generate_parameter_library)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} drake
+                          generate_parameter_library)
 
 add_subdirectory(demo)
 

--- a/demo/src/constrained_planning_demo.cpp
+++ b/demo/src/constrained_planning_demo.cpp
@@ -1,7 +1,7 @@
 #include <chrono>
 
-#include <moveit/move_group_interface/move_group_interface.h>
-#include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <moveit/move_group_interface/move_group_interface.hpp>
+#include <moveit/planning_scene_interface/planning_scene_interface.hpp>
 #include <moveit_msgs/msg/collision_object.hpp>
 #include <moveit_visual_tools/moveit_visual_tools.h>
 #include <std_msgs/msg/color_rgba.hpp>

--- a/demo/src/pipeline_testbench_main.cpp
+++ b/demo/src/pipeline_testbench_main.cpp
@@ -1,20 +1,21 @@
 #include <rclcpp/rclcpp.hpp>
 #include <memory>
-// MoveitCpp
-#include <moveit/moveit_cpp/moveit_cpp.h>
-#include <moveit/moveit_cpp/planning_component.h>
 
-#include <geometry_msgs/msg/point_stamped.h>
-#include <geometry_msgs/msg/pose.h>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+// MoveitCpp
+#include <moveit/moveit_cpp/moveit_cpp.hpp>
+#include <moveit/moveit_cpp/planning_component.hpp>
 
 #include <moveit_visual_tools/moveit_visual_tools.h>
 
 // Warehouse
-#include <moveit/warehouse/planning_scene_storage.h>
-#include <moveit/warehouse/planning_scene_storage.h>
-#include <moveit/warehouse/state_storage.h>
-#include <moveit/warehouse/constraints_storage.h>
-#include <moveit/warehouse/trajectory_constraints_storage.h>
+#include <moveit/warehouse/planning_scene_storage.hpp>
+#include <moveit/warehouse/planning_scene_storage.hpp>
+#include <moveit/warehouse/state_storage.hpp>
+#include <moveit/warehouse/constraints_storage.hpp>
+#include <moveit/warehouse/trajectory_constraints_storage.hpp>
 #include <warehouse_ros/database_loader.h>
 
 namespace rvt = rviz_visual_tools;

--- a/include/ktopt_interface/ktopt_planning_context.hpp
+++ b/include/ktopt_interface/ktopt_planning_context.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ktopt_moveit_parameters.hpp>
-#include <moveit/planning_interface/planning_interface.h>
+#include <moveit/planning_interface/planning_interface.hpp>
+#include <moveit_drake/ktopt_moveit_parameters.hpp>
 #include <shape_msgs/msg/solid_primitive.h>
 
 // relevant drake includes

--- a/include/moveit/drake/conversions.hpp
+++ b/include/moveit/drake/conversions.hpp
@@ -36,8 +36,8 @@
    Desc: TODO
 */
 
-#include <moveit/planning_scene/planning_scene.h>
-#include <moveit/robot_trajectory/robot_trajectory.h>
+#include <moveit/planning_scene/planning_scene.hpp>
+#include <moveit/robot_trajectory/robot_trajectory.hpp>
 
 #include <drake/multibody/parsing/parser.h>
 #include <drake/geometry/scene_graph.h>

--- a/src/add_toppra_time_parameterization.cpp
+++ b/src/add_toppra_time_parameterization.cpp
@@ -37,7 +37,7 @@
 */
 
 #include <moveit/drake/conversions.hpp>
-#include <moveit/planning_interface/planning_response_adapter.h>
+#include <moveit/planning_interface/planning_response_adapter.hpp>
 #include <class_loader/class_loader.hpp>
 #include <moveit/utils/logger.hpp>
 

--- a/src/ktopt_planner_manager.cpp
+++ b/src/ktopt_planner_manager.cpp
@@ -1,7 +1,7 @@
 #include <memory>
-#include <moveit/planning_interface/planning_interface.h>
-#include <moveit/planning_interface/planning_response.h>
-#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/planning_interface/planning_interface.hpp>
+#include <moveit/planning_interface/planning_response.hpp>
+#include <moveit/planning_scene/planning_scene.hpp>
 #include <moveit/utils/logger.hpp>
 #include <class_loader/class_loader.hpp>
 #include <rclcpp/node.hpp>

--- a/src/ktopt_planning_context.cpp
+++ b/src/ktopt_planning_context.cpp
@@ -16,11 +16,11 @@
 #include <drake/visualization/visualization_config.h>
 #include <drake/visualization/visualization_config_functions.h>
 
-#include <moveit/constraint_samplers/constraint_sampler_manager.h>
+#include <moveit/constraint_samplers/constraint_sampler_manager.hpp>
 #include <moveit/drake/conversions.hpp>
-#include <moveit/planning_interface/planning_interface.h>
-#include <moveit/planning_scene/planning_scene.h>
-#include <moveit/robot_state/conversions.h>
+#include <moveit/planning_interface/planning_interface.hpp>
+#include <moveit/planning_scene/planning_scene.hpp>
+#include <moveit/robot_state/conversions.hpp>
 
 #include <ktopt_interface/ktopt_planning_context.hpp>
 


### PR DESCRIPTION
This PR does a few things:
1. Fixes the `ament_export_dependencies` per #65 
2. Updates MoveIt 2 header includes to `.hpp` to prevent deprecation warnings
3. Updates the header include from the generated KTOpt parameters to match the new generate_parameter_library 0.4.0 behavior

Closes https://github.com/moveit/moveit_drake/issues/65